### PR TITLE
Use correct package name in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,9 @@ The goal of this rewrite is two-folded:
 
 ## Installation
 
-    npm install @pnpm/tabtab
+```
+pnpm add @pnpm/tabtab
+```
 
 ## Usage
 

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ The goal of this rewrite is two-folded:
 
 ## Installation
 
-    npm install tabtab
+    npm install @pnpm/tabtab
 
 ## Usage
 
@@ -77,7 +77,7 @@ Here is a basic example using
 ```js
 #! /usr/bin/env node
 
-const tabtab = require('tabtab');
+const tabtab = require('@pnpm/tabtab');
 const opts = require('minimist')(process.argv.slice(2), {
   string: ['foo', 'bar'],
   boolean: ['help', 'version', 'loglevel']


### PR DESCRIPTION
Hi, thanks for working on this fork! This is a small fix because the package mentioned in the readme is the upstream `tabtab`