### PR TITLE
Support for filesystem completion and suggestions with colons

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -118,7 +118,12 @@ const parseEnv = env => {
 const completionItem = item => {
   debug('completion item', item);
 
-  if (item.name || item.description) return item;
+  if (item.name || item.description) {
+    return {
+      name: item.name,
+      description: item.description || ''
+    };
+  }
   const shell = systemShell();
 
   let name = item;
@@ -159,10 +164,15 @@ const log = args => {
 
   // Normalize arguments if there are some Objects { name, description } in them.
   args = args.map(completionItem).map(item => {
-    const { name, description } = item;
+    const { name: rawName, description: rawDescription } = item;
+
+    const name = shell === 'zsh' ? rawName.replace(/:/g, '\\:') : rawName;
+    const description =
+      shell === 'zsh' ? rawDescription.replace(/:/g, '\\:') : rawDescription;
     let str = name;
+
     if (shell === 'zsh' && description) {
-      str = `${name.replace(/:/g, '\\:')}:${description}`;
+      str = `${name}:${description}`;
     } else if (shell === 'fish' && description) {
       str = `${name}\t${description}`;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -180,10 +180,22 @@ const log = args => {
   }
 };
 
+/**
+ * Logging utility to trigger the filesystem autocomplete.
+ *
+ * This function just returns a constant string that is then interpreted by the
+ * completion scripts as an instruction to trigger the built-in filesystem
+ * completion.
+ */
+const logFiles = () => {
+  console.log('__tabtab_complete_files__');
+};
+
 module.exports = {
   shell: systemShell,
   install,
   uninstall,
   parseEnv,
-  log
+  log,
+  logFiles
 };

--- a/lib/scripts/bash.sh
+++ b/lib/scripts/bash.sh
@@ -16,6 +16,11 @@ if type complete &>/dev/null; then
                            {completer} completion -- "${words[@]}" \
                            2>/dev/null)) || return $?
     IFS="$si"
+
+    if [ "$COMPREPLY" = "__tabtab_complete_files__" ]; then
+      COMPREPLY=($(compgen -f -- "$cword"))
+    fi
+
     if type __ltrim_colon_completions &>/dev/null; then
       __ltrim_colon_completions "${words[cword]}"
     fi

--- a/lib/scripts/fish.sh
+++ b/lib/scripts/fish.sh
@@ -7,7 +7,10 @@ function _{pkgname}_completion
   set completions (eval env DEBUG=\"" \"" COMP_CWORD=\""$words\"" COMP_LINE=\""$cmd \"" COMP_POINT=\""$cursor\"" {completer} completion -- $cmd)
 
   if [ "$completions" = "__tabtab_complete_files__" ]
-    __fish_complete_path (commandline -ct)
+    set -l matches (commandline -ct)*
+    if [ -n "$matches" ]
+      __fish_complete_path (commandline -ct)
+    end
   else
     for completion in $completions
       echo -e $completion

--- a/lib/scripts/fish.sh
+++ b/lib/scripts/fish.sh
@@ -2,14 +2,18 @@
 function _{pkgname}_completion
   set cmd (commandline -o)
   set cursor (commandline -C)
-  set words (node -pe "'$cmd'.split(' ').length")
+  set words (count $cmd)
 
   set completions (eval env DEBUG=\"" \"" COMP_CWORD=\""$words\"" COMP_LINE=\""$cmd \"" COMP_POINT=\""$cursor\"" {completer} completion -- $cmd)
 
-  for completion in $completions
-    echo -e $completion
+  if [ "$completions" = "__tabtab_complete_files__" ]
+    __fish_complete_path (commandline -ct)
+  else
+    for completion in $completions
+      echo -e $completion
+    end
   end
 end
 
-complete -f -d '{pkgname}' -c {pkgname} -a "(eval _{pkgname}_completion)"
+complete -f -d '{pkgname}' -c {pkgname} -a "(_{pkgname}_completion)"
 ###-end-{pkgname}-completion-###

--- a/lib/scripts/zsh.sh
+++ b/lib/scripts/zsh.sh
@@ -7,7 +7,11 @@ if type compdef &>/dev/null; then
     IFS=$'\n' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" {completer} completion -- "${words[@]}"))
     IFS=$si
 
-    _describe 'values' reply
+    if [ "$reply" = "__tabtab_complete_files__" ]; then
+      _files
+    else
+      _describe 'values' reply
+    fi
   }
   compdef _{pkgname}_completion {pkgname}
 fi

--- a/readme.md
+++ b/readme.md
@@ -229,6 +229,22 @@ items with `:` in them.
 Note that you can call `tabtab.log()` multiple times if you prefer to do so, it
 simply logs to the console in sequence.
 
+#### Filesystem completion
+
+If you have a parameter that expects a path to some file, you could want to let
+the shell use its native autocompletion. This saves you the work of writing
+custom filesystem autocomplete logic. Plus, the native autocomplete has a better
+handling of things like dircolors or hidden files.
+
+To trigger the filesystem completion, use `tabtab.logFiles()` without any
+argument.
+
+```js
+if (previousFlag === '--file') {
+  tabtab.logFiles();
+}
+```
+
 ### 3. Parsing env
 
 If you ever want to add more intelligent completion, you'll need to check and

--- a/test/log.js
+++ b/test/log.js
@@ -121,4 +121,23 @@ describe('tabtab.log', () => {
     ]);
     process.env.SHELL = shell;
   });
+
+  it('tabtab.log should escape ":" when name is given as an object without description', () => {
+    const shell = process.env.SHELL;
+    process.env.SHELL = '/usr/bin/zsh';
+    const logs = logTestHelper([
+      'foo:bar',
+      { name: 'foo:bar' },
+      { name: 'foo:bar', description: 'A command' },
+      { name: 'foo:bar', description: 'The foo:bar command' }
+    ]);
+
+    assert.deepStrictEqual(logs, [
+      'foo:bar',
+      'foo\\:bar',
+      'foo\\:bar:A command',
+      'foo\\:bar:The foo\\:bar command'
+    ]);
+    process.env.SHELL = shell;
+  });
 });


### PR DESCRIPTION
Closes #3.
Closes #4.

This PR adds a `logFiles` command that can be used to instruct the shell to just use the native filesystem autocompletion. This is done by returning an specific string (`__tabtab_complete_files__`). The shell scripts were modified to handle this. The `fish` shell also has some extra modifications, as recommended here: https://github.com/fish-shell/fish-shell/issues/7530#issuecomment-739472268

Besides that, this also adds better support for completions with colons. The problem, as explained in #3, was that if you have a completion in zsh with a `:` but no description, there was no way to use it.