### PR TITLE
Fix missing awaits for enquirer.prompt

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -30,7 +30,7 @@ const prompt = async () => {
 
   Object.assign(finalAnswers, { location, shell });
 
-  const { locationOK } = enquirer.prompt({
+  const { locationOK } = await enquirer.prompt({
     type: 'confirm',
     name: 'locationOK',
     message: `We will install completion to ${location}, is it ok ?`
@@ -42,7 +42,7 @@ const prompt = async () => {
   }
 
   // otherwise, ask for specific **absolute** path
-  const { userLocation } = enquirer.prompt({
+  const { userLocation } = await enquirer.prompt({
     name: 'userLocation',
     message: 'Which path then ? Must be absolute.',
     type: 'input',


### PR DESCRIPTION
Running `pnpm install-completions` causes the following output.

```
✔ Which Shell do you use ? · fish
Very well, we will install using undefined
? Which path then ? Must be absolute. ‣ ? We will install completion to ~/.config/fish/config.fish, is it ok ? (y/$HOME/.local/share/npm/lib/node_modules/pnpm/dist/pnpm.js:8450
      throw new Error("options.location is required");
            ^

Error: options.location is required
    at Object.install ($HOME/.local/share/npm/lib/node_modules/pnpm/dist/pnpm.js:8450:13)
    at install ($HOME/.local/share/npm/lib/node_modules/pnpm/dist/pnpm.js:8557:21)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at async $HOME/.local/share/npm/lib/node_modules/pnpm/dist/pnpm.js:123194:7
```

Only one of the prompts in the file `lib/prompt.js` is actually awaited. This PR fixes the rest.