### PR TITLE
Support PowerShell completions

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,19 +1,22 @@
 const BASH_LOCATION = '~/.bashrc';
 const FISH_LOCATION = '~/.config/fish/config.fish';
 const ZSH_LOCATION = '~/.zshrc';
+const PWSH_LOCATION = '~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1';
 const COMPLETION_DIR = '~/.config/tabtab';
 const TABTAB_SCRIPT_NAME = '__tabtab';
 
 const SHELL_LOCATIONS = {
   bash: '~/.bashrc',
   zsh: '~/.zshrc',
-  fish: '~/.config/fish/config.fish'
+  fish: '~/.config/fish/config.fish',
+  pwsh: '~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1'
 };
 
 module.exports = {
   BASH_LOCATION,
   ZSH_LOCATION,
   FISH_LOCATION,
+  PWSH_LOCATION,
   COMPLETION_DIR,
   TABTAB_SCRIPT_NAME,
   SHELL_LOCATIONS

--- a/lib/index.js
+++ b/lib/index.js
@@ -189,7 +189,7 @@ const log = args => {
 
     if (shell === 'zsh' && description) {
       str = `${name}:${description}`;
-    } else if (shell === 'fish' && description) {
+    } else if ((shell === 'fish' || shell === 'pwsh') && description) {
       str = `${name}\t${description}`;
     }
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -60,6 +60,16 @@ const locationFromShell = (shell = systemShell()) => {
 };
 
 /**
+ * Helper to return a supported extension for the SHELL provided.
+ *
+ * @param {String} shell - Shell value to test against, defaults to system shell.
+ */
+const extensionFromShell = (shell = systemShell()) => {
+  if (shell === 'pwsh') return 'ps1';
+  return 'sh';
+};
+
+/**
  * Helper to return the source line to add depending on the SHELL provided or detected.
  *
  * If the provided SHELL is not known, it returns the source line for a Bash shell.
@@ -187,7 +197,7 @@ const writeToShellConfig = async ({ location, name, shell }) => {
   const scriptname = path.join(
     COMPLETION_DIR,
     shell,
-    `${TABTAB_SCRIPT_NAME}.${shell}`
+    `${TABTAB_SCRIPT_NAME}.${extensionFromShell(shell)}`
   );
 
   const filename = location;
@@ -220,10 +230,14 @@ const writeToTabtabScript = async ({ name, shell }) => {
   const filename = path.join(
     COMPLETION_DIR,
     shell,
-    `${TABTAB_SCRIPT_NAME}.${shell}`
+    `${TABTAB_SCRIPT_NAME}.${extensionFromShell(shell)}`
   );
 
-  const scriptname = path.join(COMPLETION_DIR, shell, `${name}.${shell}`);
+  const scriptname = path.join(
+    COMPLETION_DIR,
+    shell,
+    `${name}.${extensionFromShell(shell)}`
+  );
 
   // Check if tabtab completion file already has this line in it
   const existing = await checkFilenameForLine(filename, scriptname);
@@ -247,7 +261,7 @@ const writeToTabtabScript = async ({ name, shell }) => {
  */
 const writeToCompletionScript = async ({ name, completer, shell }) => {
   const filename = untildify(
-    path.join(COMPLETION_DIR, shell, `${name}.${shell}`)
+    path.join(COMPLETION_DIR, shell, `${name}.${extensionFromShell(shell)}`)
   );
 
   const script = scriptFromShell(shell);
@@ -395,7 +409,7 @@ const uninstall = async (options = { name: '', shell: '' }) => {
   }
 
   const completionScript = untildify(
-    path.join(COMPLETION_DIR, shell, `${name}.${shell}`)
+    path.join(COMPLETION_DIR, shell, `${name}.${extensionFromShell(shell)}`)
   );
 
   // First, lets remove the completion script itself
@@ -406,7 +420,11 @@ const uninstall = async (options = { name: '', shell: '' }) => {
 
   // Then the lines in ~/.config/tabtab/__tabtab.shell
   const tabtabScript = untildify(
-    path.join(COMPLETION_DIR, shell, `${TABTAB_SCRIPT_NAME}.${shell}`)
+    path.join(
+      COMPLETION_DIR,
+      shell,
+      `${TABTAB_SCRIPT_NAME}.${extensionFromShell(shell)}`
+    )
   );
   await removeLinesFromFilename(tabtabScript, name);
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -15,6 +15,7 @@ const {
   BASH_LOCATION,
   FISH_LOCATION,
   ZSH_LOCATION,
+  PWSH_LOCATION,
   COMPLETION_DIR,
   TABTAB_SCRIPT_NAME
 } = require('./constants');
@@ -34,6 +35,10 @@ const scriptFromShell = (shell = systemShell()) => {
     return path.join(__dirname, 'scripts/zsh.sh');
   }
 
+  if (shell === 'pwsh') {
+    return path.join(__dirname, 'scripts/pwsh.ps1');
+  }
+
   // For Bash and others
   return path.join(__dirname, 'scripts/bash.sh');
 };
@@ -50,6 +55,7 @@ const locationFromShell = (shell = systemShell()) => {
   if (shell === 'bash') return untildify(BASH_LOCATION);
   if (shell === 'zsh') return untildify(ZSH_LOCATION);
   if (shell === 'fish') return untildify(FISH_LOCATION);
+  if (shell === 'pwsh') return untildify(PWSH_LOCATION);
   return BASH_LOCATION;
 };
 
@@ -71,6 +77,10 @@ const sourceLineForShell = (scriptname, shell = systemShell()) => {
     return `[[ -f ${scriptname} ]] && . ${scriptname} || true`;
   }
 
+  if (shell === 'pwsh') {
+    return `if (Test-Path ${scriptname}) { . ${scriptname} }`;
+  }
+
   // For Bash and others
   return `[ -f ${scriptname} ] && . ${scriptname} || true`;
 };
@@ -86,9 +96,11 @@ const isInShellConfig = filename =>
     BASH_LOCATION,
     ZSH_LOCATION,
     FISH_LOCATION,
+    PWSH_LOCATION,
     untildify(BASH_LOCATION),
     untildify(ZSH_LOCATION),
-    untildify(FISH_LOCATION)
+    untildify(FISH_LOCATION),
+    untildify(PWSH_LOCATION)
   ].includes(filename);
 
 /**

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -15,7 +15,7 @@ const prompt = async () => {
       type: 'select',
       name: 'shell',
       message: 'Which Shell do you use ?',
-      choices: ['bash', 'zsh', 'fish'],
+      choices: ['bash', 'zsh', 'fish', 'pwsh'],
       default: 'bash'
     }
   ];

--- a/lib/scripts/pwsh.ps1
+++ b/lib/scripts/pwsh.ps1
@@ -1,0 +1,191 @@
+# powershell completion for {pkgname} -*- shell-script -*-
+
+Register-ArgumentCompleter -CommandName '{pkgname}' -ScriptBlock {
+    param(
+            $WordToComplete,
+            $CommandAst,
+            $CursorPosition
+        )
+
+    function __{pkgname}_debug {
+        if ($env:BASH_COMP_DEBUG_FILE) {
+            "$args" | Out-File -Append -FilePath "$env:BASH_COMP_DEBUG_FILE"
+        }
+    }
+
+    filter __{pkgname}_escapeStringWithSpecialChars {
+        $_ -replace '\s|#|@|\$|;|,|''|\{|\}|\(|\)|"|`|\||<|>|&','`$&'
+    }
+
+    # Get the current command line and convert into a string
+    $Command = $CommandAst.CommandElements
+    $Command = "$Command"
+
+    __{pkgname}_debug ""
+    __{pkgname}_debug "========= starting completion logic =========="
+    __{pkgname}_debug "WordToComplete: $WordToComplete Command: $Command CursorPosition: $CursorPosition"
+
+    # The user could have moved the cursor backwards on the command-line.
+    # We need to trigger completion from the $CursorPosition location, so we need
+    # to truncate the command-line ($Command) up to the $CursorPosition location.
+    # Make sure the $Command is longer then the $CursorPosition before we truncate.
+    # This happens because the $Command does not include the last space.
+    if ($Command.Length -gt $CursorPosition) {
+        $Command=$Command.Substring(0,$CursorPosition)
+    }
+    __{pkgname}_debug "Truncated command: $Command"
+
+    # Prepare the command to request completions for the program.
+    # Split the command at the first space to separate the program and arguments.
+    $Program,$Arguments = $Command.Split(" ",2)
+    $RequestComp="$Program completion"
+    __{pkgname}_debug "RequestComp: $RequestComp"
+
+    # we cannot use $WordToComplete because it
+    # has the wrong values if the cursor was moved
+    # so use the last argument
+    if ($WordToComplete -ne "" ) {
+        $WordToComplete = $Arguments.Split(" ")[-1]
+    }
+    __{pkgname}_debug "New WordToComplete: $WordToComplete"
+
+
+    # Check for flag with equal sign
+    $IsEqualFlag = ($WordToComplete -Like "--*=*" )
+    if ( $IsEqualFlag ) {
+        __{pkgname}_debug "Completing equal sign flag"
+        # Remove the flag part
+        $Flag,$WordToComplete = $WordToComplete.Split("=",2)
+    }
+
+    if ( $WordToComplete -eq "" -And ( -Not $IsEqualFlag )) {
+        # If the last parameter is complete (there is a space following it)
+        # We add an extra empty parameter so we can indicate this to the go method.
+        __{pkgname}_debug "Adding extra empty parameter"
+        # We need to use `"`" to pass an empty argument a "" or '' does not work!!!
+        $Command="$Command" + ' `"`"'
+    }
+
+    __{pkgname}_debug "Calling $RequestComp"
+
+    $oldenv = ($env:SHELL, $env:COMP_CWORD, $env:COMP_LINE, $env:COMP_POINT)
+    $env:SHELL = "pwsh"
+    $env:COMP_CWORD = $Command.Split(" ").Count - 1
+    $env:COMP_POINT = $CursorPosition
+    $env:COMP_LINE = $Command
+
+    try {
+        #call the command store the output in $out and redirect stderr and stdout to null
+        # $Out is an array contains each line per element
+        Invoke-Expression -OutVariable out "$RequestComp" 2>&1 | Out-Null
+    } finally {
+        ($env:SHELL, $env:COMP_CWORD, $env:COMP_LINE, $env:COMP_POINT) = $oldenv
+    }
+
+    __{pkgname}_debug "The completions are: $Out"
+
+    $Longest = 0
+    $Values = $Out | ForEach-Object {
+        #Split the output in name and description
+        $Name, $Description = $_.Split("`t",2)
+        __{pkgname}_debug "Name: $Name Description: $Description"
+
+        # Look for the longest completion so that we can format things nicely
+        if ($Longest -lt $Name.Length) {
+            $Longest = $Name.Length
+        }
+
+        # Set the description to a one space string if there is none set.
+        # This is needed because the CompletionResult does not accept an empty string as argument
+        if (-Not $Description) {
+            $Description = " "
+        }
+        @{Name="$Name";Description="$Description"}
+    }
+
+
+    $Space = " "
+    $Values = $Values | Where-Object {
+        # filter the result
+        if (-not $WordToComplete.StartsWith("-") -and $_.Name.StartsWith("-")) {
+            # skip flag completions unless a dash is present
+            return
+        } else {
+            $_.Name -like "$WordToComplete*"
+        }
+
+        # Join the flag back if we have an equal sign flag
+        if ( $IsEqualFlag ) {
+            __{pkgname}_debug "Join the equal sign flag back to the completion value"
+            $_.Name = $Flag + "=" + $_.Name
+        }
+    }
+
+    # Get the current mode
+    $Mode = (Get-PSReadLineKeyHandler | Where-Object {$_.Key -eq "Tab" }).Function
+    __{pkgname}_debug "Mode: $Mode"
+
+    $Values | ForEach-Object {
+
+        # store temporary because switch will overwrite $_
+        $comp = $_
+
+        # PowerShell supports three different completion modes
+        # - TabCompleteNext (default windows style - on each key press the next option is displayed)
+        # - Complete (works like bash)
+        # - MenuComplete (works like zsh)
+        # You set the mode with Set-PSReadLineKeyHandler -Key Tab -Function <mode>
+
+        # CompletionResult Arguments:
+        # 1) CompletionText text to be used as the auto completion result
+        # 2) ListItemText   text to be displayed in the suggestion list
+        # 3) ResultType     type of completion result
+        # 4) ToolTip        text for the tooltip with details about the object
+
+        switch ($Mode) {
+
+            # bash like
+            "Complete" {
+
+                if ($Values.Length -eq 1) {
+                    __{pkgname}_debug "Only one completion left"
+
+                    # insert space after value
+                    [System.Management.Automation.CompletionResult]::new($($comp.Name | __{pkgname}_escapeStringWithSpecialChars) + $Space, "$($comp.Name)", 'ParameterValue', "$($comp.Description)")
+
+                } else {
+                    # Add the proper number of spaces to align the descriptions
+                    while($comp.Name.Length -lt $Longest) {
+                        $comp.Name = $comp.Name + " "
+                    }
+
+                    # Check for empty description and only add parentheses if needed
+                    if ($($comp.Description) -eq " " ) {
+                        $Description = ""
+                    } else {
+                        $Description = "  ($($comp.Description))"
+                    }
+
+                    [System.Management.Automation.CompletionResult]::new("$($comp.Name)$Description", "$($comp.Name)$Description", 'ParameterValue', "$($comp.Description)")
+                }
+             }
+
+            # zsh like
+            "MenuComplete" {
+                # insert space after value
+                # MenuComplete will automatically show the ToolTip of
+                # the highlighted value at the bottom of the suggestions.
+                [System.Management.Automation.CompletionResult]::new($($comp.Name | __{pkgname}_escapeStringWithSpecialChars) + $Space, "$($comp.Name)", 'ParameterValue', "$($comp.Description)")
+            }
+
+            # TabCompleteNext and in case we get something unknown
+            Default {
+                # Like MenuComplete but we don't want to add a space here because
+                # the user need to press space anyway to get the completion.
+                # Description will not be shown because that's not possible with TabCompleteNext
+                [System.Management.Automation.CompletionResult]::new($($comp.Name | __{pkgname}_escapeStringWithSpecialChars), "$($comp.Name)", 'ParameterValue', "$($comp.Description)")
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
I've done some initial work to add support for (un)installing and generating PowerShell completions files. The actual completion script is derived from [cobra](https://github.com/spf13/cobra/blob/main/powershell_completions.go)  and [pnpm.ps1](https://gist.github.com/jcwillox/027b6c105d190abfa0333c13836f5bec).

This PR is related to https://github.com/pnpm/pnpm/issues/3771 and https://github.com/mklabs/tabtab/issues/26.

The PR currently uses the default profile location for PSv6+, and won't install completions in the correct location for users of PSv5. The method for identifying the shell discussed below would allow for detecting the correct location.

* **6+**: ~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1
* **5**: ~/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1

Currently, the main issue with this PR is that is cannot detect whether the user is running PowerShell, as PowerShell does not set the `SHELL` environment variable. This means that while uninstalling does technically work, the shell must be explicitly set.
The completion script currently sets `SHELL=pwsh` to work around this.

There is of course a way to detect PowerShell, I need to update the `systemShell` function to identify the shell based on the parent processes executable. This, however, requires an additional dependency, https://www.npmjs.com/package/find-process, looks like a good choice. Additionally, there's the question of whether we'd still respect the `SHELL` variable, as it usually represents the users login shell and not necessarily their current shell.