### PR TITLE
feat: stricter types, uninstall from all shells

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -6,21 +6,21 @@ const SUPPORTED_SHELLS = /** @type {const} */ (['bash', 'fish', 'pwsh', 'zsh']);
  * @typedef {typeof SUPPORTED_SHELLS[number]} SupportedShell
  */
 
-/** @type {Record.<SupportedShell, String>} */
-const SHELL_LOCATIONS = {
+/** @satisfies {Record.<SupportedShell, String>} */
+const SHELL_LOCATIONS = /** @type {const} */ ({
   bash: '~/.bashrc',
   zsh: '~/.zshrc',
   fish: '~/.config/fish/config.fish',
   pwsh: '~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1'
-};
+});
 
-/** @type {Record.<SupportedShell, String>} */
-const COMPLETION_FILE_EXT = {
+/** @satisfies {Record.<SupportedShell, String>} */
+const COMPLETION_FILE_EXT = /** @type {const} */ ({
   bash: 'bash',
   fish: 'fish',
   pwsh: 'ps1',
   zsh: 'zsh',
-};
+});
 
 module.exports = {
   COMPLETION_DIR,

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,12 @@
 const COMPLETION_DIR = '~/.config/tabtab';
 
-/** @type {Record.<String, String>} */
+const SUPPORTED_SHELLS = /** @type {const} */ (['bash', 'fish', 'pwsh', 'zsh']);
+
+/**
+ * @typedef {typeof SUPPORTED_SHELLS[number]} SupportedShell
+ */
+
+/** @type {Record.<SupportedShell, String>} */
 const SHELL_LOCATIONS = {
   bash: '~/.bashrc',
   zsh: '~/.zshrc',
@@ -8,7 +14,7 @@ const SHELL_LOCATIONS = {
   pwsh: '~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1'
 };
 
-/** @type {Record.<String, String>} */
+/** @type {Record.<SupportedShell, String>} */
 const COMPLETION_FILE_EXT = {
   bash: 'bash',
   fish: 'fish',
@@ -18,6 +24,7 @@ const COMPLETION_FILE_EXT = {
 
 module.exports = {
   COMPLETION_DIR,
+  SUPPORTED_SHELLS,
   SHELL_LOCATIONS,
   COMPLETION_FILE_EXT,
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,10 +1,6 @@
-const BASH_LOCATION = '~/.bashrc';
-const FISH_LOCATION = '~/.config/fish/config.fish';
-const ZSH_LOCATION = '~/.zshrc';
-const PWSH_LOCATION = '~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1';
 const COMPLETION_DIR = '~/.config/tabtab';
 
-/** @type {Record.<String, String | undefined>} */
+/** @type {Record.<String, String>} */
 const SHELL_LOCATIONS = {
   bash: '~/.bashrc',
   zsh: '~/.zshrc',
@@ -12,7 +8,7 @@ const SHELL_LOCATIONS = {
   pwsh: '~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1'
 };
 
-/** @type {Record.<String, String | undefined>} */
+/** @type {Record.<String, String>} */
 const COMPLETION_FILE_EXT = {
   bash: 'bash',
   fish: 'fish',
@@ -21,10 +17,6 @@ const COMPLETION_FILE_EXT = {
 };
 
 module.exports = {
-  BASH_LOCATION,
-  ZSH_LOCATION,
-  FISH_LOCATION,
-  PWSH_LOCATION,
   COMPLETION_DIR,
   SHELL_LOCATIONS,
   COMPLETION_FILE_EXT,

--- a/lib/filename.js
+++ b/lib/filename.js
@@ -2,7 +2,7 @@ const { COMPLETION_FILE_EXT } = require('./constants');
 
 /**
  * Get a template file name for the SHELL provided.
- * @param {String} shell
+ * @param {import('./constants').SupportedShell} shell
  * @returns {String}
  */
 const templateFileName = shell => {
@@ -16,7 +16,7 @@ const templateFileName = shell => {
 /**
  * Get a extension for the completion file of the SHELL (without the leading period).
  * @param {String} name
- * @param {String} shell
+ * @param {import('./constants').SupportedShell} shell
  * @returns {String}
  */
 const completionFileName = (name, shell) => {
@@ -29,7 +29,7 @@ const completionFileName = (name, shell) => {
 
 /**
  * Get a tabtab file name for the SHELL provided.
- * @param {String} shell
+ * @param {import('./constants').SupportedShell} shell
  * @returns {String}
  */
 const tabtabFileName = shell => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,7 +162,7 @@ const parseEnv = env => {
  * Helper to normalize String and Objects with { name, description } when logging out.
  *
  * @param {String | CompletionItem} item - Item to normalize
- * @param {String} shell
+ * @param {SupportedShell} shell
  * @returns {CompletionItem} normalized items
  */
 const completionItem = (item, shell) => {
@@ -198,9 +198,9 @@ const completionItem = (item, shell) => {
  *
  * @param {Array.<CompletionItem | String>} args to log, Strings or Objects with name and
  * description property.
- * @param {String} shell
+ * @param {SupportedShell} shell
  */
-const log = (args, shell = systemShell()) => {
+const log = (args, shell) => {
   if (!Array.isArray(args)) {
     throw new Error('log: Invalid arguments, must be an array');
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,13 @@ const { tabtabDebug, systemShell } = require('./utils');
 const debug = tabtabDebug('tabtab');
 
 /**
+ * Check if a shell is supported.
+ * @param {String} shell - Shell to check.
+ * @returns {shell is SupportedShell}
+ */
+const isShellSupported = shell => (/** @type {ReadonlyArray.<String>} */ (SUPPORTED_SHELLS)).includes(shell);
+
+/**
  * Construct a completion script.
  * @param {Object} options - Options object.
  * @param {String} options.name - The package configured for completion
@@ -247,6 +254,7 @@ const logFiles = () => {
 module.exports = {
   SUPPORTED_SHELLS,
   shell: systemShell,
+  isShellSupported,
   getCompletionScript,
   install,
   uninstall,

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,6 @@ const install = async (options) => {
     return;
   }
 
-  /** @type {any} */
   const { location, shell } = await prompt();
 
   await installer.install({

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ const getCompletionScript = async ({ name, completer, shell }) => {
  * @param {Object} options to use with namely `name` and `completer`
  * @param {String} options.name
  * @param {String} options.completer
- * @param {SupportedShell} options.shell
+ * @param {SupportedShell} [options.shell]
  */
 const install = async (options) => {
   const { name, completer } = options;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,11 @@
-const { SHELL_LOCATIONS } = require('./constants');
+const { SUPPORTED_SHELLS, SHELL_LOCATIONS } = require('./constants');
 const prompt = require('./prompt');
 const installer = require('./installer');
 const { tabtabDebug, systemShell } = require('./utils');
+
+/**
+ * @typedef {import('./constants').SupportedShell} SupportedShell
+ */
 
 // If TABTAB_DEBUG env is set, make it so that debug statements are also log to
 // TABTAB_DEBUG file provided.
@@ -12,7 +16,7 @@ const debug = tabtabDebug('tabtab');
  * @param {Object} options - Options object.
  * @param {String} options.name - The package configured for completion
  * @param {String} options.completer - The program the will act as the completer for the `name` program
- * @param {String} options.shell
+ * @param {SupportedShell} options.shell
  * @returns {Promise.<String>}
  */
 const getCompletionScript = async ({ name, completer, shell }) => {
@@ -32,7 +36,7 @@ const getCompletionScript = async ({ name, completer, shell }) => {
  * @param {Object} options to use with namely `name` and `completer`
  * @param {String} options.name
  * @param {String} options.completer
- * @param {String} options.shell
+ * @param {SupportedShell} options.shell
  */
 const install = async (options) => {
   const { name, completer } = options;
@@ -67,9 +71,9 @@ const install = async (options) => {
 /**
  * @param {Object} options
  * @param {String} options.name
- * @param {String} options.shell
+ * @param {SupportedShell} options.shell
  */
-const uninstall = async (options = { name: '', shell: systemShell() }) => {
+const uninstall = async options => {
   const { name, shell } = options;
   if (!name) throw new TypeError('options.name is required');
 
@@ -240,6 +244,7 @@ const logFiles = () => {
 };
 
 module.exports = {
+  SUPPORTED_SHELLS,
   shell: systemShell,
   getCompletionScript,
   install,

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,15 +28,12 @@ const getCompletionScript = async ({ name, completer, shell }) => {
 }
 
 /**
- * Install and enable completion on user system. It'll ask for:
+ * Install and enable completion on user system.
  *
- * - SHELL (bash, zsh or fish)
- * - Path to shell script (with sensible defaults)
- *
- * @param {Object} options to use with namely `name` and `completer`
- * @param {String} options.name
- * @param {String} options.completer
- * @param {SupportedShell} [options.shell]
+ * @param {Object} options
+ * @param {String} options.name - Name of the program whose completion needs to be installed.
+ * @param {String} options.completer - Name of the program that provides completion service.
+ * @param {SupportedShell} [options.shell] - Name of the target shell. If not specified, it'll prompt the user.
  */
 const install = async (options) => {
   const { name, completer } = options;

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,9 +69,14 @@ const install = async (options) => {
 };
 
 /**
+ * Uninstall shell completion for one program from one or all supported shells.
+ *
+ * It also removes the relevant scripts if no more completion are installed on
+ * the system.
+ *
  * @param {Object} options
- * @param {String} options.name
- * @param {SupportedShell} options.shell
+ * @param {String} options.name - Name of the target program.
+ * @param {SupportedShell} [options.shell] - The target shell language. If not specified, target all supported shells.
  */
 const uninstall = async options => {
   const { name, shell } = options;

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -23,22 +23,26 @@ const {
 } = require('./filename');
 
 /**
+ * @typedef {import('./constants').SupportedShell} SupportedShell
+ */
+
+/**
  * Helper to return the correct script template based on the SHELL provided
  *
- * @param {String} shell - Shell to base the check on, defaults to system shell.
+ * @param {SupportedShell} shell - Shell to base the check on, defaults to system shell.
  * @returns {String} The template script content, defaults to Bash for shell we don't know yet
  */
-const scriptFromShell = (shell = systemShell()) => path.join(__dirname, 'templates', templateFileName(shell));
+const scriptFromShell = shell => path.join(__dirname, 'templates', templateFileName(shell));
 
 /**
  * Helper to return the expected location for SHELL config file, based on the
  * provided shell value.
  *
- * @param {String} shell - Shell value to test against
+ * @param {SupportedShell} shell - Shell value to test against
  * @returns {String} Either ~/.bashrc, ~/.zshrc or ~/.config/fish/config.fish,
  * untildified. Defaults to ~/.bashrc if provided SHELL is not valid.
  */
-const locationFromShell = (shell = systemShell()) => {
+const locationFromShell = shell => {
   const location = SHELL_LOCATIONS[shell];
   if (!location) {
     throw new Error(`Unsupported shell: ${shell}`);
@@ -172,7 +176,7 @@ const writeLineToFilename = ({ filename, scriptname, name, shell }) => new Promi
  * @param {String} options.location - The SHELL script location (~/.bashrc, ~/.zshrc or
  *    ~/.config/fish/config.fish)
  * @param {String} options.name - The package configured for completion
- * @param {String} options.shell
+ * @param {SupportedShell} options.shell options.shell
  */
 const writeToShellConfig = async ({ location, name, shell }) => {
   const scriptname = path.join(
@@ -204,7 +208,7 @@ const writeToShellConfig = async ({ location, name, shell }) => {
  *
  * @param {Object} options - Options object with
  * @param {String} options.name - The package configured for completion
- * @param {String} options.shell
+ * @param {SupportedShell} options.shell
  */
 const writeToTabtabScript = async ({ name, shell }) => {
   const filename = path.join(
@@ -233,7 +237,7 @@ const writeToTabtabScript = async ({ name, shell }) => {
  * @param {Object} options - Options object
  * @param {String} options.name - The package configured for completion
  * @param {String} options.completer - The program the will act as the completer for the `name` program
- * @param {String} [options.shell]
+ * @param {SupportedShell} options.shell
  * @returns {Promise.<String>}
  */
 const getCompletionScript = async ({ name, completer, shell }) => {
@@ -255,7 +259,7 @@ const getCompletionScript = async ({ name, completer, shell }) => {
  * @param {Object} options - Options object with
  * @param {String} options.name - The package configured for completion
  * @param {String} options.completer - The binary that will act as the completer for `name` program
- * @param {String} options.shell
+ * @param {SupportedShell} options.shell
  */
 const writeToCompletionScript = async ({ name, completer, shell }) => {
   const filename = untildify(
@@ -286,12 +290,14 @@ const writeToCompletionScript = async ({ name, completer, shell }) => {
  *    for `name` program. Can be the same.
  * @param {String} options.location - The SHELL script config location (~/.bashrc, ~/.zshrc or
  *    ~/.config/fish/config.fish)
- * @param {String} options.shell - the target shell language
+ * @param {SupportedShell} options.shell - the target shell language
  */
-const install = async (
-  options = { name: '', completer: '', location: '', shell: systemShell() }
-) => {
+const install = async options => {
   debug('Install with options', options);
+  if (!options) {
+    throw new Error('options is required');
+  }
+
   if (!options.name) {
     throw new Error('options.name is required');
   }
@@ -390,10 +396,14 @@ const removeLinesFromFilename = async (filename, name) => {
  *
  * @param {Object} options - Options object with
  * @param {String} options.name - The package name to look for
- * @param {String} options.shell - the target shell language
+ * @param {SupportedShell} options.shell - the target shell language
  */
-const uninstall = async (options = { name: '', shell: '' }) => {
+const uninstall = async options => {
   debug('Uninstall with options', options);
+  if (!options) {
+    throw new Error('options is required');
+  }
+
   const { name, shell } = options;
 
   if (!name) {

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -3,6 +3,7 @@ const path = require('path');
 const untildify = require('untildify');
 const { promisify } = require('util');
 const { tabtabDebug, systemShell, exists } = require('./utils');
+const { SUPPORTED_SHELLS } = require('./constants')
 
 const debug = tabtabDebug('tabtab:installer');
 
@@ -394,9 +395,12 @@ const removeLinesFromFilename = async (filename, name) => {
  * It also removes the relevant scripts if no more completion are installed on
  * the system.
  *
+ * The `shell` option is optional. If it is not specified, this function would
+ * uninstall from all supported shell languages.
+ *
  * @param {Object} options - Options object with
  * @param {String} options.name - The package name to look for
- * @param {SupportedShell} options.shell - the target shell language
+ * @param {SupportedShell} [options.shell] - The target shell language (if only uninstall from one language)
  */
 const uninstall = async options => {
   debug('Uninstall with options', options);
@@ -409,8 +413,10 @@ const uninstall = async options => {
   if (!name) {
     throw new Error('Unable to uninstall if options.name is missing');
   }
+
   if (!shell) {
-    throw new Error('Unable to uninstall if options.shell is missing');
+    await Promise.all(SUPPORTED_SHELLS.map(shell => uninstall({ name, shell })));
+    return;
   }
 
   const completionScript = untildify(

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -57,10 +57,9 @@ const locationFromShell = shell => {
  * If the provided SHELL is not known, it returns the source line for a Bash shell.
  *
  * @param {String} scriptname - The script to source
- * @param {String} shell - Shell to base the check on, defaults to system
- * shell.
+ * @param {SupportedShell} shell - Shell to base the check on
  */
-const sourceLineForShell = (scriptname, shell = systemShell()) => {
+const sourceLineForShell = (scriptname, shell) => {
   if (shell === 'fish') {
     return `[ -f ${scriptname} ]; and . ${scriptname}; or true`;
   }
@@ -73,8 +72,11 @@ const sourceLineForShell = (scriptname, shell = systemShell()) => {
     return `if (Test-Path ${scriptname}) { . ${scriptname} }`;
   }
 
-  // For Bash and others
-  return `[ -f ${scriptname} ] && . ${scriptname} || true`;
+  if (shell === 'bash') {
+    return `[ -f ${scriptname} ] && . ${scriptname} || true`;
+  }
+
+  throw new Error(`Unsupported shell: ${shell}`);
 };
 
 /**
@@ -131,7 +133,7 @@ const checkFilenameForLine = async (filename, line) => {
  * @param {String} options.filename - The file to modify.
  * @param {String} options.scriptname - The line to add sourcing this file.
  * @param {String} options.name - The package being configured.
- * @param {String} options.shell
+ * @param {SupportedShell} options.shell
  * @returns {Promise.<void>}
  */
 const writeLineToFilename = ({ filename, scriptname, name, shell }) => new Promise((

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -389,18 +389,14 @@ const removeLinesFromFilename = async (filename, name) => {
 };
 
 /**
- * Here the idea is to uninstall a given package completion from internal
- * tabtab scripts and / or the SHELL config.
+ * Uninstall shell completion for one program from one or all supported shells.
  *
  * It also removes the relevant scripts if no more completion are installed on
  * the system.
  *
- * The `shell` option is optional. If it is not specified, this function would
- * uninstall from all supported shell languages.
- *
- * @param {Object} options - Options object with
- * @param {String} options.name - The package name to look for
- * @param {SupportedShell} [options.shell] - The target shell language (if only uninstall from one language)
+ * @param {Object} options
+ * @param {String} options.name - Name of the target program.
+ * @param {SupportedShell} [options.shell] - The target shell language. If not specified, target all supported shells.
  */
 const uninstall = async options => {
   debug('Uninstall with options', options);

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -12,10 +12,7 @@ const unlink = promisify(fs.unlink);
 const mkdir = promisify(fs.mkdir);
 
 const {
-  BASH_LOCATION,
-  FISH_LOCATION,
-  ZSH_LOCATION,
-  PWSH_LOCATION,
+  SHELL_LOCATIONS,
   COMPLETION_DIR,
 } = require('./constants');
 
@@ -42,11 +39,11 @@ const scriptFromShell = (shell = systemShell()) => path.join(__dirname, 'templat
  * untildified. Defaults to ~/.bashrc if provided SHELL is not valid.
  */
 const locationFromShell = (shell = systemShell()) => {
-  if (shell === 'bash') return untildify(BASH_LOCATION);
-  if (shell === 'zsh') return untildify(ZSH_LOCATION);
-  if (shell === 'fish') return untildify(FISH_LOCATION);
-  if (shell === 'pwsh') return untildify(PWSH_LOCATION);
-  return BASH_LOCATION;
+  const location = SHELL_LOCATIONS[shell];
+  if (!location) {
+    throw new Error(`Unsupported shell: ${shell}`);
+  }
+  return untildify(location);
 };
 
 /**
@@ -83,14 +80,14 @@ const sourceLineForShell = (scriptname, shell = systemShell()) => {
  */
 const isInShellConfig = filename =>
   [
-    BASH_LOCATION,
-    ZSH_LOCATION,
-    FISH_LOCATION,
-    PWSH_LOCATION,
-    untildify(BASH_LOCATION),
-    untildify(ZSH_LOCATION),
-    untildify(FISH_LOCATION),
-    untildify(PWSH_LOCATION)
+    SHELL_LOCATIONS['bash'],
+    SHELL_LOCATIONS['zsh'],
+    SHELL_LOCATIONS['fish'],
+    SHELL_LOCATIONS['pwsh'],
+    untildify(SHELL_LOCATIONS['bash']),
+    untildify(SHELL_LOCATIONS['zsh']),
+    untildify(SHELL_LOCATIONS['fish']),
+    untildify(SHELL_LOCATIONS['pwsh']),
   ].includes(filename);
 
 /**

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -87,14 +87,14 @@ const sourceLineForShell = (scriptname, shell) => {
  */
 const isInShellConfig = filename =>
   [
-    SHELL_LOCATIONS['bash'],
-    SHELL_LOCATIONS['zsh'],
-    SHELL_LOCATIONS['fish'],
-    SHELL_LOCATIONS['pwsh'],
-    untildify(SHELL_LOCATIONS['bash']),
-    untildify(SHELL_LOCATIONS['zsh']),
-    untildify(SHELL_LOCATIONS['fish']),
-    untildify(SHELL_LOCATIONS['pwsh']),
+    SHELL_LOCATIONS.bash,
+    SHELL_LOCATIONS.zsh,
+    SHELL_LOCATIONS.fish,
+    SHELL_LOCATIONS.pwsh,
+    untildify(SHELL_LOCATIONS.bash),
+    untildify(SHELL_LOCATIONS.zsh),
+    untildify(SHELL_LOCATIONS.fish),
+    untildify(SHELL_LOCATIONS.pwsh),
   ].includes(filename);
 
 /**

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -4,6 +4,10 @@ const { SHELL_LOCATIONS } = require('./constants');
 const debug = require('./utils/tabtabDebug')('tabtab:prompt');
 
 /**
+ * @typedef {import('./constants').SupportedShell} SupportedShell
+ */
+
+/**
  * Asks user about SHELL and desired location.
  *
  * It is too difficult to check spawned SHELL, the user has to use chsh before
@@ -26,7 +30,11 @@ const prompt = async () => {
   const { shell } = await enquirer.prompt(questions);
   debug('answers', shell);
 
-  const location = SHELL_LOCATIONS[shell];
+  if (!(shell in SHELL_LOCATIONS)) {
+    throw new Error(`Unsupported shell: ${shell}`);
+  }
+
+  const location = SHELL_LOCATIONS[/** @type {SupportedShell} */ (shell)];
   debug(`Will install completion to ${location}`);
 
   Object.assign(finalAnswers, { location, shell });

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -8,10 +8,18 @@ const debug = require('./utils/tabtabDebug')('tabtab:prompt');
  */
 
 /**
+ * @typedef {Object} PromptAnswer
+ * @property {SupportedShell} shell
+ * @property {String} location
+ */
+
+/**
  * Asks user about SHELL and desired location.
  *
  * It is too difficult to check spawned SHELL, the user has to use chsh before
  * it is reflected in process.env.SHELL
+ *
+ * @returns {Promise.<PromptAnswer>}
  */
 const prompt = async () => {
   const questions = [
@@ -24,10 +32,7 @@ const prompt = async () => {
     }
   ];
 
-  const finalAnswers = {};
-
-  // @ts-ignore
-  const { shell } = await enquirer.prompt(questions);
+  const { shell } = /** @type {{ shell: SupportedShell }} */ (await enquirer.prompt(questions));
   debug('answers', shell);
 
   if (!(shell in SHELL_LOCATIONS)) {
@@ -37,7 +42,7 @@ const prompt = async () => {
   const location = SHELL_LOCATIONS[/** @type {SupportedShell} */ (shell)];
   debug(`Will install completion to ${location}`);
 
-  Object.assign(finalAnswers, { location, shell });
+  const initialAnswer = { location, shell };
 
   // @ts-ignore
   const { locationOK } = await enquirer.prompt({
@@ -47,8 +52,8 @@ const prompt = async () => {
   });
 
   if (locationOK) {
-    debug('location is ok, return', finalAnswers);
-    return finalAnswers;
+    debug('location is ok, return', initialAnswer);
+    return initialAnswer;
   }
 
   // otherwise, ask for specific **absolute** path
@@ -63,9 +68,8 @@ const prompt = async () => {
     }
   });
   console.log(`Very well, we will install using ${userLocation}`);
-  Object.assign(finalAnswers, { location: userLocation });
 
-  return finalAnswers;
+  return { shell, location: userLocation };
 };
 
 module.exports = prompt;

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -44,12 +44,11 @@ const prompt = async () => {
 
   const initialAnswer = { location, shell };
 
-  // @ts-ignore
-  const { locationOK } = await enquirer.prompt({
+  const { locationOK } = /** @type {{ locationOK: Boolean }} */ (await enquirer.prompt({
     type: 'confirm',
     name: 'locationOK',
     message: `We will install completion to ${location}, is it ok ?`
-  });
+  }));
 
   if (locationOK) {
     debug('location is ok, return', initialAnswer);
@@ -57,8 +56,7 @@ const prompt = async () => {
   }
 
   // otherwise, ask for specific **absolute** path
-  // @ts-ignore
-  const { userLocation } = await enquirer.prompt({
+  const { userLocation } = /** @type {{ userLocation: String }} */ (await enquirer.prompt({
     name: 'userLocation',
     message: 'Which path then ? Must be absolute.',
     type: 'input',
@@ -66,7 +64,7 @@ const prompt = async () => {
       debug('Validating input', input);
       return path.isAbsolute(input);
     }
-  });
+  }));
   console.log(`Very well, we will install using ${userLocation}`);
 
   return { shell, location: userLocation };

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -1,6 +1,6 @@
 const enquirer = require('enquirer');
 const path = require('path');
-const { SHELL_LOCATIONS } = require('./constants');
+const { SUPPORTED_SHELLS, SHELL_LOCATIONS } = require('./constants');
 const debug = require('./utils/tabtabDebug')('tabtab:prompt');
 
 /**
@@ -19,7 +19,7 @@ const prompt = async () => {
       type: 'select',
       name: 'shell',
       message: 'Which Shell do you use ?',
-      choices: ['bash', 'zsh', 'fish', 'pwsh'],
+      choices: SUPPORTED_SHELLS,
       default: 'bash'
     }
   ];

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "mkdir -p ~/.config/tabtab && c8 mocha --timeout 5000",
+    "test": "c8 mocha --timeout 5000",
     "typecheck": "pnpm run build && tsc -p test --noEmit",
     "build": "tsc -p lib",
     "prepublishOnly": "pnpm run build",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "mkdir -p ~/.config/tabtab && DEBUG='tabtab*' c8 mocha --timeout 5000",
+    "test": "mkdir -p ~/.config/tabtab && c8 mocha --timeout 5000",
     "typecheck": "pnpm run build && tsc -p test --noEmit",
     "build": "tsc -p lib",
     "prepublishOnly": "pnpm run build",
     "posttest": "npm run eslint",
-    "mocha": "DEBUG='tabtab*' mocha --timeout 5000",
+    "mocha": "mocha --timeout 5000",
     "coverage": "c8 report --reporter=text-lcov | coveralls",
     "coverage-html": "npm run mocha && c8 report --reporter=html && serve coverage",
     "eslint": "eslint lib/ test/",

--- a/test/getCompletionScript.js
+++ b/test/getCompletionScript.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const { getCompletionScript } = require('..');
 
 describe('getCompletionScript gets the right completion script for', () => {
-  for (const shell of ['bash', 'fish', 'zsh']) {
+  for (const shell of /** @type {const} */ (['bash', 'fish', 'zsh'])) {
     it(shell, async () => {
       const received = await getCompletionScript({
         name: 'foo',

--- a/test/getCompletionScript.js
+++ b/test/getCompletionScript.js
@@ -1,33 +1,21 @@
 const assert = require('assert');
 const fs = require('fs');
-const { getCompletionScript } = require('..');
+const { getCompletionScript, SUPPORTED_SHELLS } = require('..');
+const { COMPLETION_FILE_EXT } = require('../lib/constants');
 
 describe('getCompletionScript gets the right completion script for', () => {
-  for (const shell of /** @type {const} */ (['bash', 'fish', 'zsh'])) {
+  for (const shell of SUPPORTED_SHELLS) {
     it(shell, async () => {
       const received = await getCompletionScript({
         name: 'foo',
         completer: 'foo-complete',
         shell
       });
-      const expected = fs.readFileSync(require.resolve(`../lib/templates/completion.${shell}`), 'utf8')
+      const expected = fs.readFileSync(require.resolve(`../lib/templates/completion.${COMPLETION_FILE_EXT[shell]}`), 'utf8')
         .replace(/\{pkgname\}/g, 'foo')
         .replace(/{completer}/g, 'foo-complete')
         .replace(/\r?\n/g, '\n');
       assert.equal(received, expected);
     });
   }
-
-  it('pwsh', async () => {
-    const received = await getCompletionScript({
-      name: 'foo',
-      completer: 'foo-complete',
-      shell: 'pwsh'
-    });
-    const expected = fs.readFileSync(require.resolve(`../lib/templates/completion.ps1`), 'utf8')
-      .replace(/\{pkgname\}/g, 'foo')
-      .replace(/{completer}/g, 'foo-complete')
-      .replace(/\r?\n/g, '\n');
-    assert.equal(received, expected);
-  });
 });

--- a/test/installer.js
+++ b/test/installer.js
@@ -27,7 +27,10 @@ describe('installer', () => {
   });
 
   it('install rejects on missing options', async () => {
-    await assert.rejects(async () => install(), /options.name is required/);
+    // @ts-ignore
+    await assert.rejects(async () => install(), /options is required/);
+    // @ts-ignore
+    await assert.rejects(async () => install({}), /options.name is required/);
     await assert.rejects(
       // @ts-ignore
       async () => install({ name: 'foo ' }),
@@ -43,7 +46,14 @@ describe('installer', () => {
 
   it('uninstall rejects on missing options', async () => {
     await assert.rejects(
+      // @ts-ignore
       async () => uninstall(),
+      /options is required/,
+      'Uninstall should throw the expected message when name is missing'
+    );
+    await assert.rejects(
+      // @ts-ignore
+      async () => uninstall({}),
       /Unable to uninstall if options.name is missing/,
       'Uninstall should throw the expected message when name is missing'
     );

--- a/test/installer.js
+++ b/test/installer.js
@@ -57,12 +57,6 @@ describe('installer', () => {
       /Unable to uninstall if options.name is missing/,
       'Uninstall should throw the expected message when name is missing'
     );
-    await assert.rejects(
-      // @ts-ignore
-      async () => uninstall({ name: 'foo' }),
-      /Unable to uninstall if options.shell is missing/,
-      'Uninstall should throw the expected message when shell is missing'
-    );
   });
 
   it('has writeToShellConfig / writeToCompletionScript functions', () => {

--- a/test/isShellSupported.js
+++ b/test/isShellSupported.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const { isShellSupported, SUPPORTED_SHELLS } = require('..');
+
+describe('isShellSupported', () => {
+  it('returns true for supported shells', () => {
+    assert.deepStrictEqual(
+      SUPPORTED_SHELLS.filter(shell => isShellSupported(shell)),
+      SUPPORTED_SHELLS,
+    );
+  })
+
+  it('returns false for unsupported shells', () => {
+    assert.strictEqual(isShellSupported('unknown'), false);
+  })
+})

--- a/test/log.js
+++ b/test/log.js
@@ -54,29 +54,24 @@ describe('tabtab.log', () => {
   });
 
   it('tabtab.log normalize String and Objects, with description stripped out on Bash', () => {
-    const shell = process.env.SHELL;
-    process.env.SHELL = '/bin/bash';
     const logs = logTestHelper([
       { name: '--foo', description: 'Foo options' },
       { name: '--bar', description: 'Bar option' },
       'foobar',
       'barfoo:barfoo is not foobar'
-    ]);
+    ], 'bash');
 
     assert.equal(logs.length, 4);
     assert.deepStrictEqual(logs, ['--foo', '--bar', 'foobar', 'barfoo']);
-    process.env.SHELL = shell;
   });
 
   it('tabtab.log with description NOT stripped out on Zsh', () => {
-    const shell = process.env.SHELL;
-    process.env.SHELL = '/usr/bin/zsh';
     const logs = logTestHelper([
       { name: '--foo', description: 'Foo option' },
       { name: '--bar', description: 'Bar option' },
       'foobar',
       'barfoo:barfoo is not foobar'
-    ]);
+    ], 'zsh');
 
     assert.equal(logs.length, 4);
     assert.deepStrictEqual(logs, [
@@ -85,18 +80,15 @@ describe('tabtab.log', () => {
       'foobar',
       'barfoo:barfoo is not foobar'
     ]);
-    process.env.SHELL = shell;
   });
 
   it('tabtab.log with description NOT stripped out on fish', () => {
-    const shell = process.env.SHELL;
-    process.env.SHELL = '/usr/bin/fish';
     const logs = logTestHelper([
       { name: '--foo', description: 'Foo option' },
       { name: '--bar', description: 'Bar option' },
       'foobar',
       'barfoo:barfoo is not foobar'
-    ]);
+    ], 'fish');
 
     assert.equal(logs.length, 4);
     assert.deepStrictEqual(logs, [
@@ -105,18 +97,15 @@ describe('tabtab.log', () => {
       'foobar',
       'barfoo\tbarfoo is not foobar'
     ]);
-    process.env.SHELL = shell;
   });
 
   it('tabtab.log could use {name, description} for completions with ":" in them', () => {
-    const shell = process.env.SHELL;
-    process.env.SHELL = '/usr/bin/zsh';
     const logs = logTestHelper([
       { name: '--foo:bar', description: 'Foo option' },
       { name: '--bar:foo', description: 'Bar option' },
       'foobar',
       'barfoo:barfoo is not foobar'
-    ]);
+    ], 'zsh');
 
     assert.equal(logs.length, 4);
     assert.deepStrictEqual(logs, [
@@ -125,18 +114,15 @@ describe('tabtab.log', () => {
       'foobar',
       'barfoo:barfoo is not foobar'
     ]);
-    process.env.SHELL = shell;
   });
 
   it('tabtab.log should escape ":" when name is given as an object without description', () => {
-    const shell = process.env.SHELL;
-    process.env.SHELL = '/usr/bin/zsh';
     const logs = logTestHelper([
       'foo:bar',
       { name: 'foo:bar' },
       { name: 'foo:bar', description: 'A command' },
       { name: 'foo:bar', description: 'The foo:bar command' }
-    ]);
+    ], 'zsh');
 
     assert.deepStrictEqual(logs, [
       'foo:bar',
@@ -144,6 +130,5 @@ describe('tabtab.log', () => {
       'foo\\:bar:A command',
       'foo\\:bar:The foo\\:bar command'
     ]);
-    process.env.SHELL = shell;
   });
 });

--- a/test/tabtab-install.js
+++ b/test/tabtab-install.js
@@ -50,7 +50,7 @@ describe('tabtab.install()', () => {
   it('rejects on unknown shell target', async () => {
     await assert.rejects(
       async () =>
-        tabtab.install({ name: 'foo', completer: 'foo', shell: 'unknown' }),
+        tabtab.install({ name: 'foo', completer: 'foo', shell: /** @type {any} */ ('unknown') }),
       /Couldn't find shell location for unknown/
     );
   });


### PR DESCRIPTION
* Added `SUPPORTED_SHELLS` to public API.
* Added `SupportedShell` to public API.
* Added `isShellSupported` to public API.
* Changed all type of `shell` and `options.shell` from `string` to `SupportedShell`.
* Added option to uninstall from all supported shells.