### PR TITLE
chore: remove posttest

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "typecheck": "pnpm run build && tsc -p test --noEmit",
     "build": "tsc -p lib",
     "prepublishOnly": "pnpm run build",
-    "posttest": "npm run eslint",
     "mocha": "mocha --timeout 5000",
     "coverage": "c8 report --reporter=text-lcov | coveralls",
     "coverage-html": "npm run mocha && c8 report --reporter=html && serve coverage",


### PR DESCRIPTION
eslint suddenly fails, so it needs to be removed for the time being